### PR TITLE
Oryx Helm chart impl nginx-hls-cdn

### DIFF
--- a/oryx-nginx-hls/.helmignore
+++ b/oryx-nginx-hls/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/oryx-nginx-hls/Chart.yaml
+++ b/oryx-nginx-hls/Chart.yaml
@@ -1,0 +1,49 @@
+apiVersion: v2
+name: oryx-nginx-hls
+description: Oryx(SRS Stack) is an all-in-one, one-click, and open-source video solution for creating online
+  services on cloud or self-hosting. Built with SRS, FFmpeg, and WebRTC, it supports various protocols
+  and offers features like authentication, multi-platform streaming, recording, transcoding, virtual
+  live events, automatic HTTPS, and HTTP Open API.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v5.15.15"
+
+home: https://helm.ossrs.io/stable
+icon: https://ossrs.io/lts/en-us/img/srs-220x234.png
+keywords:
+  - srs
+  - media
+  - video
+  - rtmp
+  - hls
+  - webrtc
+  - srt
+sources:
+  - https://github.com/ossrs/srs-helm/tree/v1.0.7/oryx
+
+maintainers:
+  - name: Winlin
+    email: winlinvip@gmail.com
+    url: https://github.com/ossrs/srs-helm
+
+annotations:
+  category: Infrastructure
+  licenses: MIT

--- a/oryx-nginx-hls/Chart.yaml
+++ b/oryx-nginx-hls/Chart.yaml
@@ -24,7 +24,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v5.15.15"
+appVersion: "5.15.20"
 
 home: https://helm.ossrs.io/stable
 icon: https://ossrs.io/lts/en-us/img/srs-220x234.png

--- a/oryx-nginx-hls/charts/nginx-cache/.helmignore
+++ b/oryx-nginx-hls/charts/nginx-cache/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/oryx-nginx-hls/charts/nginx-cache/Chart.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: nginx-cache
+description: A Helm chart for nginx cache
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/oryx-nginx-hls/charts/nginx-cache/templates/NOTES.txt
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "nginx-cache.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "nginx-cache.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "nginx-cache.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "nginx-cache.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/_helpers.tpl
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nginx-cache.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nginx-cache.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nginx-cache.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nginx-cache.labels" -}}
+helm.sh/chart: {{ include "nginx-cache.chart" . }}
+{{ include "nginx-cache.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nginx-cache.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nginx-cache.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nginx-cache.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nginx-cache.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-config
-  namespace: default
 data:
   nginx.edge.http.conf.template: |
     proxy_cache_path  /data/nginx-cache levels=1:2 keys_zone=srs_cache:8m max_size=1000m inactive=600m;
@@ -20,7 +19,7 @@ data:
 
         location ~ /.+/.*\.(m3u8)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ORYX_SERVER}.default.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+            proxy_pass http://${ORYX_SERVER}.${K8S_NAMESPACE}.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri$args;
@@ -32,7 +31,7 @@ data:
 
         location ~ /.+/.*\.(ts)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ORYX_SERVER}.default.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+            proxy_pass http://${ORYX_SERVER}.${K8S_NAMESPACE}.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri;

--- a/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
@@ -4,8 +4,8 @@ metadata:
   name: nginx-config
 data:
   nginx.edge.http.conf.template: |
-    proxy_cache_path  /data/nginx-cache levels=1:2 keys_zone=srs_cache:8m max_size=1000m inactive=600m;
-    proxy_temp_path /data/nginx-cache/tmp;
+    proxy_cache_path  {{ .Values.nginxCachePath }} levels=1:2 keys_zone=srs_cache:8m max_size=1000m inactive=600m;
+    proxy_temp_path {{ .Values.nginxCachePath }}/tmp;
 
     server {
         listen 80 default_server;
@@ -19,26 +19,28 @@ data:
 
         location ~ /.+/.*\.(m3u8)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ORYX_SERVER}.${K8S_NAMESPACE}.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+            proxy_pass http://${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri$args;
             proxy_cache_valid  200 302 ${SRS_M3U8_EXPIRE}s;
             add_header X-Cache-Status $upstream_cache_status;
 
-            resolver kube-dns.kube-system.svc.cluster.local;
+            # the internal DNS of k8s cluster, keep it if use service name as address.
+            # e.g. [service name].[namespace].svc.cluster.local as address
+            # resolver kube-dns.kube-system.svc.cluster.local;
         }
 
         location ~ /.+/.*\.(ts)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ORYX_SERVER}.${K8S_NAMESPACE}.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+            proxy_pass http://${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri;
             proxy_cache_valid  200 302 ${SRS_TS_EXPIRE}s;
             add_header X-Cache-Status $upstream_cache_status;
-
-            resolver kube-dns.kube-system.svc.cluster.local;
+            
+            # resolver kube-dns.kube-system.svc.cluster.local;
         }
     }
 

--- a/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
@@ -1,0 +1,73 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: default
+data:
+  nginx.edge.http.conf.template: |
+    proxy_cache_path  /data/nginx-cache levels=1:2 keys_zone=srs_cache:8m max_size=1000m inactive=600m;
+    proxy_temp_path /data/nginx-cache/tmp;
+
+    server {
+        listen 80 default_server;
+        listen [::]:80 default_server;
+
+        proxy_cache_valid  404 10s;
+        proxy_cache_lock on;
+        proxy_cache_lock_age 300s;
+        proxy_cache_lock_timeout 300s;
+        proxy_cache_min_uses 1;
+
+        location ~ /.+/.*\.(m3u8)$ {
+            proxy_set_header Host $host;
+            proxy_pass http://${ORYX_SERVER}.default.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+
+            proxy_cache srs_cache;
+            proxy_cache_key $scheme$proxy_host$uri$args;
+            proxy_cache_valid  200 302 ${SRS_M3U8_EXPIRE}s;
+            add_header X-Cache-Status $upstream_cache_status;
+
+            resolver kube-dns.kube-system.svc.cluster.local;
+        }
+
+        location ~ /.+/.*\.(ts)$ {
+            proxy_set_header Host $host;
+            proxy_pass http://${ORYX_SERVER}.default.svc.cluster.local:${ORYX_SERVER_PORT}$request_uri;
+
+            proxy_cache srs_cache;
+            proxy_cache_key $scheme$proxy_host$uri;
+            proxy_cache_valid  200 302 ${SRS_TS_EXPIRE}s;
+            add_header X-Cache-Status $upstream_cache_status;
+
+            resolver kube-dns.kube-system.svc.cluster.local;
+        }
+    }
+
+  index.html: |
+    <html>
+    <head>
+        <title>Nginx Cache</title>
+        <meta charset="utf-8">
+        <style>
+            .code {
+                background-color: rgb(217, 222, 227);
+                padding: 2px;
+                overflow: auto;
+                font-size: 85%;
+                line-height: 1.45;
+                border-radius: 6px;
+                word-break: normal;
+                word-wrap: normal;
+                box-sizing: border-box;
+                white-space: pre;
+            }
+        </style>
+    </head>
+    <body>
+        <div>
+            <h1>Nginx</h1>
+            <p>Congratulations! Nginx Ready!<a href="https://github.com/ossrs/srs">SRS</a> works!</p>
+            <hr/>
+            <h2>Nginx Cache</h2>
+        </div>
+    </body>

--- a/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/configmap.yaml
@@ -19,7 +19,7 @@ data:
 
         location ~ /.+/.*\.(m3u8)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
+            proxy_pass http://${ {{- .Values.global.oryxSvcTcp | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxSvcTcp | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri$args;
@@ -33,7 +33,7 @@ data:
 
         location ~ /.+/.*\.(ts)$ {
             proxy_set_header Host $host;
-            proxy_pass http://${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxHostName | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
+            proxy_pass http://${ {{- .Values.global.oryxSvcTcp | upper | replace "-" "_"}}_SERVICE_HOST}:${ {{- .Values.global.oryxSvcTcp | upper | replace "-" "_"}}_SERVICE_PORT_HTTP}$request_uri;
 
             proxy_cache srs_cache;
             proxy_cache_key $scheme$proxy_host$uri;

--- a/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: 80
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
@@ -64,6 +64,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if .Values.global.hlsFragment }}
+            - name: SRS_M3U8_EXPIRE
+              value: {{ .Values.global.hlsFragment | quote }}
+            {{- end }}
       volumes:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nginx-cache.fullname" . }}
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "nginx-cache.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "nginx-cache.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "nginx-cache.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+            - name: config-volume
+              mountPath: /etc/nginx/templates/default.conf.template
+              subPath: nginx.edge.http.conf.template
+            - name: config-volume
+              mountPath: /etc/nginx/html/index.html
+              subPath: index.html
+            - name: cache-volume
+              mountPath: /data/nginx-cache
+          env:
+            # Overwrite the config by conf.
+            {{- range $key, $value := .Values.conf }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- if .Values.global.oryxHostName }}
+            - name: ORYX_SERVER
+              value: {{ .Values.global.oryxHostName }}
+            {{- end }}
+            {{- if .Values.global.oryxHostPort }}
+            - name: ORYX_SERVER_PORT
+              value: {{ .Values.global.oryxHostPort | quote }}
+            {{- end }}
+      volumes:
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: cache-volume
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
             - name: ORYX_SERVER_PORT
               value: {{ .Values.global.oryxHostPort | quote }}
             {{- end }}
+            - name: K8S_NAMESPACE
+              value: {{ .Release.Namespace }}
       volumes:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/deployment.yaml
@@ -57,23 +57,13 @@ spec:
               mountPath: /etc/nginx/html/index.html
               subPath: index.html
             - name: cache-volume
-              mountPath: /data/nginx-cache
+              mountPath: {{ .Values.nginxCachePath }}
           env:
             # Overwrite the config by conf.
             {{- range $key, $value := .Values.conf }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            {{- if .Values.global.oryxHostName }}
-            - name: ORYX_SERVER
-              value: {{ .Values.global.oryxHostName }}
-            {{- end }}
-            {{- if .Values.global.oryxHostPort }}
-            - name: ORYX_SERVER_PORT
-              value: {{ .Values.global.oryxHostPort | quote }}
-            {{- end }}
-            - name: K8S_NAMESPACE
-              value: {{ .Release.Namespace }}
       volumes:
       {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/hpa.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "nginx-cache.fullname" . }}
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "nginx-cache.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/ingress.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nginx-cache.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/service.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nginx-cache.fullname" . }}
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "nginx-cache.selectorLabels" . | nindent 4 }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/serviceaccount.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nginx-cache.serviceAccountName" . }}
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/oryx-nginx-hls/charts/nginx-cache/templates/tests/test-connection.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nginx-cache.fullname" . }}-test-connection"
+  labels:
+    {{- include "nginx-cache.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "nginx-cache.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -49,7 +49,7 @@ securityContext:
 
 service:
   type: LoadBalancer
-  port: 80
+  port: 1080
 
 ingress:
   enabled: false

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -1,0 +1,119 @@
+# Default values for nginx-cache.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# The configuration for nginx cach.
+# must have ORYX_SERVER, ORYX_SERVER_PORT SRS_M3U8_EXPIRE, SRS_TS_EXPIRE
+conf:
+  # ORYX_SERVER: "127.0.0.1:2022"
+  # ORYX_SERVER_PORT: 2080
+  SRS_M3U8_EXPIRE: 10
+  SRS_TS_EXPIRE: 3600
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -17,8 +17,8 @@ fullnameOverride: ""
 # The configuration for nginx cach.
 # must have ORYX_SERVER, ORYX_SERVER_PORT SRS_M3U8_EXPIRE, SRS_TS_EXPIRE
 conf:
-  # ORYX_SERVER: "127.0.0.1:2022"
-  # ORYX_SERVER_PORT: 2080
+  ORYX_SERVER: "127.0.0.1" # .Values.global.oryxHostName can overwrite this
+  ORYX_SERVER_PORT: 80     # .Values.global.oryxHostPort can overwrite this
   SRS_M3U8_EXPIRE: 10
   SRS_TS_EXPIRE: 3600
 

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -91,8 +91,8 @@ readinessProbe:
 
 autoscaling:
   enabled: true
-  minReplicas: 2
-  maxReplicas: 5
+  minReplicas: 1
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -17,7 +17,6 @@ fullnameOverride: ""
 # The configuration for nginx cach.
 # must have SRS_M3U8_EXPIRE, SRS_TS_EXPIRE
 conf:
-  SRS_M3U8_EXPIRE: 10
   SRS_TS_EXPIRE: 3600
 
 serviceAccount:

--- a/oryx-nginx-hls/charts/nginx-cache/values.yaml
+++ b/oryx-nginx-hls/charts/nginx-cache/values.yaml
@@ -15,10 +15,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 # The configuration for nginx cach.
-# must have ORYX_SERVER, ORYX_SERVER_PORT SRS_M3U8_EXPIRE, SRS_TS_EXPIRE
+# must have SRS_M3U8_EXPIRE, SRS_TS_EXPIRE
 conf:
-  ORYX_SERVER: "127.0.0.1" # .Values.global.oryxHostName can overwrite this
-  ORYX_SERVER_PORT: 80     # .Values.global.oryxHostPort can overwrite this
   SRS_M3U8_EXPIRE: 10
   SRS_TS_EXPIRE: 3600
 
@@ -117,3 +115,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+nginxCachePath: /data/nginx-cache

--- a/oryx-nginx-hls/templates/NOTES.txt
+++ b/oryx-nginx-hls/templates/NOTES.txt
@@ -6,14 +6,14 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oryx-nginx-hls.fullname" . }})
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Values.global.oryxHostName }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "oryx-nginx-hls.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oryx-nginx-hls.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ .Values.global.oryxHostName }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.global.oryxHostName }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  visit oryx: http://$SERVICE_IP:{{ .Values.global.oryxHostPort }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oryx-nginx-hls.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/oryx-nginx-hls/templates/NOTES.txt
+++ b/oryx-nginx-hls/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "oryx-nginx-hls.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "oryx-nginx-hls.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "oryx-nginx-hls.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "oryx-nginx-hls.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/oryx-nginx-hls/templates/_helpers.tpl
+++ b/oryx-nginx-hls/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oryx-nginx-hls.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oryx-nginx-hls.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oryx-nginx-hls.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oryx-nginx-hls.labels" -}}
+helm.sh/chart: {{ include "oryx-nginx-hls.chart" . }}
+{{ include "oryx-nginx-hls.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oryx-nginx-hls.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oryx-nginx-hls.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oryx-nginx-hls.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oryx-nginx-hls.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/oryx-nginx-hls/templates/deployment.yaml
+++ b/oryx-nginx-hls/templates/deployment.yaml
@@ -8,6 +8,8 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "oryx-nginx-hls.selectorLabels" . | nindent 6 }}

--- a/oryx-nginx-hls/templates/deployment.yaml
+++ b/oryx-nginx-hls/templates/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oryx-nginx-hls.fullname" . }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "oryx-nginx-hls.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "oryx-nginx-hls.selectorLabels" . | nindent 8 }}
+    spec:
+      volumes:
+        - name: srs-pv-storage
+          persistentVolumeClaim:
+            claimName: srs-pv-claim
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "oryx-nginx-hls.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          volumeMounts:
+            - mountPath: "/data"
+              name: srs-pv-storage
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath | quote }}
+              {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["./bootstrap"]
+          ports:
+            - name: rtmp
+              containerPort: 1935
+              protocol: TCP
+            - name: http
+              containerPort: 2022
+              protocol: TCP
+            - name: https
+              containerPort: 2443
+              protocol: TCP
+            - name: srt
+              containerPort: 10080
+              protocol: UDP
+            - name: rtc
+              containerPort: 8000
+              protocol: UDP
+          env:
+            # The general default config.
+            - name: SRS_PLATFORM
+              value: "helm"
+            # Overwrite the config by conf.
+            {{- range $key, $value := .Values.conf }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            # Overwrite the config by env.
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            # Overwrite by special item.
+            {{- if .Values.candidate }}
+            - name: SRS_RTC_SERVER_CANDIDATE
+              value: {{ .Values.candidate | quote }}
+            {{- end }}
+            # For multiple instances expose different ports.
+            - name: RTMP_PORT
+              value: {{ .Values.service.rtmp | quote }}
+            - name: SRT_PORT
+              value: {{ .Values.service.srt | quote }}
+            - name: RTC_PORT
+              value: {{ .Values.service.rtc | quote }}
+            # Enable self-sign certificate by default.
+            - name: AUTO_SELF_SIGNED_CERTIFICATE
+              value: "on"
+            # Enable dns name lookup.
+            - name: NAME_LOOKUP
+              value: "on"
+            # For Oryx, we resolve the ip in platform.
+            - name: SRS_RTC_SERVER_API_AS_CANDIDATES
+              value: "off"
+            # For Oryx, never detect network ip, because it runs in docker, and the ip is private.
+            - name: SRS_RTC_SERVER_USE_AUTO_DETECT_NETWORK_IP
+              value: "off"
+            # For Oryx, should always enable daemon.
+            - name: SRS_DAEMON
+              value: "on"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/oryx-nginx-hls/templates/deployment.yaml
+++ b/oryx-nginx-hls/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: rtc
               containerPort: 8000
               protocol: UDP
+            - name: rtc-over-tcp
+              containerPort: 8000
+              protocol: TCP
           env:
             # The general default config.
             - name: SRS_PLATFORM

--- a/oryx-nginx-hls/templates/deployment.yaml
+++ b/oryx-nginx-hls/templates/deployment.yaml
@@ -21,9 +21,13 @@ spec:
         {{- include "oryx-nginx-hls.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
-        - name: srs-pv-storage
+        - name: oryx-pv-storage
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: srs-pv-claim
+            claimName: oryx-pv-claim
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -35,7 +39,7 @@ spec:
         - name: {{ .Chart.Name }}
           volumeMounts:
             - mountPath: "/data"
-              name: srs-pv-storage
+              name: oryx-pv-storage
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath | quote }}
               {{- end }}
@@ -103,11 +107,11 @@ spec:
               value: "on"
           livenessProbe:
             httpGet:
-              path: /
+              path: /terraform/v1/mgmt/versions
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /terraform/v1/mgmt/versions
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/oryx-nginx-hls/templates/deployment.yaml
+++ b/oryx-nginx-hls/templates/deployment.yaml
@@ -73,6 +73,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if .Values.global.hlsFragment }}
+            - name: SRS_VHOST_HLS_HLS_FRAGMENT
+              value: {{ .Values.global.hlsFragment | quote }}
+            {{- end }}
             # Overwrite the config by env.
             {{- range .Values.env }}
             - name: {{ .name }}

--- a/oryx-nginx-hls/templates/hpa.yaml
+++ b/oryx-nginx-hls/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oryx-nginx-hls.fullname" . }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oryx-nginx-hls.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/oryx-nginx-hls/templates/ingress.yaml
+++ b/oryx-nginx-hls/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "oryx-nginx-hls.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/oryx-nginx-hls/templates/pvc.yaml
+++ b/oryx-nginx-hls/templates/pvc.yaml
@@ -1,0 +1,31 @@
+{{- if (.Values.persistence.enabled) }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: srs-pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: srs-disk-storage
+  capacity:
+    storage: {{ .Values.persistence.storage }}
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: {{ .Values.persistence.path }}
+    type: DirectoryOrCreate
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: srs-pv-claim
+spec:
+  storageClassName: srs-disk-storage
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storage }}
+{{- end }}

--- a/oryx-nginx-hls/templates/pvc.yaml
+++ b/oryx-nginx-hls/templates/pvc.yaml
@@ -2,15 +2,15 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: srs-pv-volume
+  name: oryx-pv-volume
   labels:
     type: local
 spec:
-  storageClassName: srs-disk-storage
+  storageClassName: {{ .Values.persistence.className }}
   capacity:
     storage: {{ .Values.persistence.storage }}
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   hostPath:
     path: {{ .Values.persistence.path }}
     type: DirectoryOrCreate
@@ -20,11 +20,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: srs-pv-claim
+  name: oryx-pv-claim
 spec:
-  storageClassName: srs-disk-storage
+  storageClassName: {{ .Values.persistence.className }}
+  volumeName: oryx-pv-volume
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.persistence.storage }}

--- a/oryx-nginx-hls/templates/service.yaml
+++ b/oryx-nginx-hls/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.global.oryxHostName }}
-  name: {{ .Values.global.oryxHostName }}
+  {{- if .Values.global.oryxSvcTcp }}
+  name: {{ .Values.global.oryxSvcTcp }}
   {{- else -}}
-  name: {{ include "oryx-nginx-hls.fullname" . }}
+  name: {{ include "oryx-nginx-hls.fullname" . }}-tcp
   {{- end }}
   labels:
     {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
@@ -23,6 +23,28 @@ spec:
       port: {{ .Values.service.https }}
       targetPort: 2443
       protocol: TCP
+    - name: rtc-over-tcp
+      port: {{ .Values.service.rtc }}
+      targetPort: 8000
+      protocol: TCP
+  selector:
+    {{- include "oryx-nginx-hls.selectorLabels" . | nindent 4 }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.global.oryxSvcUdp }}
+  name: {{ .Values.global.oryxSvcUdp }}
+  {{- else -}}
+  name: {{ include "oryx-nginx-hls.fullname" . }}-udp
+  {{- end }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports: 
     - name: srt
       port: {{ .Values.service.srt }}
       targetPort: 10080

--- a/oryx-nginx-hls/templates/service.yaml
+++ b/oryx-nginx-hls/templates/service.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.global.oryxHostName }}
+  name: {{ .Values.global.oryxHostName }}
+  {{- else -}}
+  name: {{ include "oryx-nginx-hls.fullname" . }}
+  {{- end }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: rtmp
+      port: {{ .Values.service.rtmp }}
+      targetPort: 1935
+      protocol: TCP
+    - name: http
+      port: {{ .Values.service.http }}
+      targetPort: 2022
+      protocol: TCP
+    - name: https
+      port: {{ .Values.service.https }}
+      targetPort: 2443
+      protocol: TCP
+    - name: srt
+      port: {{ .Values.service.srt }}
+      targetPort: 10080
+      protocol: UDP
+    - name: rtc
+      port: {{ .Values.service.rtc }}
+      targetPort: 8000
+      protocol: UDP
+  selector:
+    {{- include "oryx-nginx-hls.selectorLabels" . | nindent 4 }}

--- a/oryx-nginx-hls/templates/serviceaccount.yaml
+++ b/oryx-nginx-hls/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oryx-nginx-hls.serviceAccountName" . }}
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/oryx-nginx-hls/templates/tests/test-connection.yaml
+++ b/oryx-nginx-hls/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "oryx-nginx-hls.fullname" . }}-test-connection"
+  labels:
+    {{- include "oryx-nginx-hls.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "oryx-nginx-hls.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -70,6 +70,8 @@ securityContext: {}
 persistence:
   ## @param persistence.enabled Enable persistence.
   enabled: true
+  ## @param persistence.className the storageClassName.
+  className: "standard"
   ## @param persistence.path The path of the hostPath.
   path: /data
   ## @param persistence.storage The size of the volume to allocate.
@@ -92,10 +94,10 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
+    - host: localhost
       paths:
         - path: /
-          pathType: ImplementationSpecific
+          pathType: Prefix
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -1,0 +1,125 @@
+# Copyright ossrs, Inc.
+# SPDX-License-Identifier: MIT
+
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+##
+
+## @section Common parameters
+##
+
+image:
+  repository: ossrs/oryx
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# The configuration for SRS can be overridden by environment variables.
+# See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf
+conf:
+  SRS_LOG_TANK: "console"
+
+# The environment variables to set in the container.
+# See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf
+env: []
+  #- name: SRS_LOG_TANK
+  #  value: "file"
+
+# The WebRTC candidate, which is your server's public IP address, can be accessed by the client.
+# See https://ossrs.io/lts/en-us/docs/v5/doc/webrtc#config-candidate for details.
+# Note that if this value is not empty, it will override the SRS_RTC_SERVER_CANDIDATE value in
+# both the {{.Values.conf}} and {{.Values.env}}.
+candidate: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## Persistence parameters
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+persistence:
+  ## @param persistence.enabled Enable persistence.
+  enabled: true
+  ## @param persistence.path The path of the hostPath.
+  path: /data
+  ## @param persistence.storage The size of the volume to allocate.
+  storage: 30Gi
+  ## @param persistence.subPath The subdirectory of the volume to mount.
+  # subPath: "0"
+
+service:
+  type: LoadBalancer
+  rtmp: 1935
+  http: 2080
+  https: 2443
+  srt: 10080
+  rtc: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  oryxHostName: oryx-host-name
+  oryxHostPort: "2080"

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -20,8 +20,10 @@ replicaCount: 1
 # See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf
 conf:
   SRS_LOG_TANK: "console"
-  # below four confs used to force HLS high performance and HLS Low Latency
-  SRS_VHOST_HLS_HLS_WINDOW: 16
+  # check the global value hlsFragment which control the duration of one ts segment.
+  # HLS_WINDOW is the max media duration in m3u8 playlist, and is also the max video latency.
+  SRS_VHOST_HLS_HLS_WINDOW: 10
+  # HLS_CTX and HLS_TS_CTX must be off for nginx edge, they will make the nginx cache missed.
   SRS_VHOST_HLS_HLS_CTX: "off"
   SRS_VHOST_HLS_HLS_TS_CTX: "off"
   # above four confs used to force HLS high performance and HLS Low Latency
@@ -129,4 +131,6 @@ affinity: {}
 
 global:
   oryxHostName: oryx-host-name
+  # hlsFragment which control the duration of one ts segment.
+  # which must be equal or greater then the SRS_M3U8_EXPIRE in nginx-cache pod.
   hlsFragment: 2

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -27,7 +27,19 @@ conf:
   SRS_VHOST_HLS_HLS_CTX: "off"
   SRS_VHOST_HLS_HLS_TS_CTX: "off"
   # above four confs used to force HLS high performance and HLS Low Latency
-
+  # config RTC Port protocol: "tcp", "udp", "all"
+  SRS_RTC_SERVER_PROTOCOL: "tcp"
+  # Wether to enable WebRTC over TCP.
+  # if you want to config RTC over TCP only
+  #   SRS_RTC_SERVER_PROTOCOL: "tcp"
+  #   SRS_RTC_SERVER_TCP_ENABLED: "on"
+  # if you want to config RTC over both TCP and UDP
+  #   SRS_RTC_SERVER_PROTOCOL: "all"
+  #   SRS_RTC_SERVER_TCP_ENABLED: "on"
+  # if you want to config RTC over UDP only
+  #   SRS_RTC_SERVER_PROTOCOL: "udp"
+  #   SRS_RTC_SERVER_TCP_ENABLED: "off"
+  SRS_RTC_SERVER_TCP_ENABLED: "on"
 # The environment variables to set in the container.
 # See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf
 env: []
@@ -38,6 +50,8 @@ env: []
 # See https://ossrs.io/lts/en-us/docs/v5/doc/webrtc#config-candidate for details.
 # Note that if this value is not empty, it will override the SRS_RTC_SERVER_CANDIDATE value in
 # both the {{.Values.conf}} and {{.Values.env}}.
+# apply a public static IP, binding it to the {{ .Values.global.oryxSvcTcp }} service.
+# config candidate to this public static IP.
 candidate: ""
 
 imagePullSecrets: []
@@ -70,7 +84,7 @@ securityContext: {}
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
 persistence:
   ## @param persistence.enabled Enable persistence.
-  enabled: true
+  enabled: false
   ## @param persistence.className the storageClassName.
   className: "standard"
   ## @param persistence.path The path of the hostPath.
@@ -130,7 +144,8 @@ tolerations: []
 affinity: {}
 
 global:
-  oryxHostName: oryx-host-name
+  oryxSvcTcp: oryx-svc-tcp
+  oryxSvcUdp: oryx-svc-udp
   # hlsFragment which control the duration of one ts segment.
   # which must be equal or greater then the SRS_M3U8_EXPIRE in nginx-cache pod.
   hlsFragment: 2

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -21,7 +21,6 @@ replicaCount: 1
 conf:
   SRS_LOG_TANK: "console"
   # below four confs used to force HLS high performance and HLS Low Latency
-  SRS_VHOST_HLS_HLS_FRAGMENT: 2
   SRS_VHOST_HLS_HLS_WINDOW: 16
   SRS_VHOST_HLS_HLS_CTX: "off"
   SRS_VHOST_HLS_HLS_TS_CTX: "off"
@@ -130,3 +129,4 @@ affinity: {}
 
 global:
   oryxHostName: oryx-host-name
+  hlsFragment: 2

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -20,6 +20,12 @@ replicaCount: 1
 # See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf
 conf:
   SRS_LOG_TANK: "console"
+  # below four confs used to force HLS high performance and HLS Low Latency
+  SRS_VHOST_HLS_HLS_FRAGMENT: 2
+  SRS_VHOST_HLS_HLS_WINDOW: 16
+  SRS_VHOST_HLS_HLS_CTX: "off"
+  SRS_VHOST_HLS_HLS_TS_CTX: "off"
+  # above four confs used to force HLS high performance and HLS Low Latency
 
 # The environment variables to set in the container.
 # See https://github.com/ossrs/srs/blob/develop/trunk/conf/full.conf

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -122,4 +122,3 @@ affinity: {}
 
 global:
   oryxHostName: oryx-host-name
-  oryxHostPort: "2080" # must be same value of service.value

--- a/oryx-nginx-hls/values.yaml
+++ b/oryx-nginx-hls/values.yaml
@@ -122,4 +122,4 @@ affinity: {}
 
 global:
   oryxHostName: oryx-host-name
-  oryxHostPort: "2080"
+  oryxHostPort: "2080" # must be same value of service.value


### PR DESCRIPTION
## Background

ref https://github.com/ossrs/oryx/tree/main/scripts/nginx-hls-cdn#nginx-hls-cdn

The commit is the k8s helm chart implementation of [nginx-hls-cdn](https://github.com/ossrs/oryx/tree/main/scripts/nginx-hls-cdn#nginx-hls-cdn). Inside a k8s cluster, deploy a oryx pod and a autoscale nginx pods that provide hls server to the frontend. 

## How to Install 
1. download this repo;
2. `helm install oryx ./oryx-nginx-hls;
3. wait the containers download and pods deployed to k8s cluster;
4. check pod status by `kubectl get pods`, and k8s services by `kubectl get services`;
5. visit oryx front end by web browser: `http://localhost:2080/mgmt/` (replace the localhost with the k8s service ip);
6. enable HLS high performance mode and HLS Low Latency if you want to, by this path in above frontend webui: System -> HLS.
7. push the video stream to the srs server;
8. play HLS stream by the k8s service ip of the nginx LoadBalancer. (check `kubectl get services`) e.g. `ffplay -i http://127.0.0.1/live/livestream.m3u8`

## How to do benchmark in your local pc?
1. scripts to publish 50 streams to oryx or srs.
```bash
#!/bin/bash
for ((i=1;i<=50;i++)); 
do 
   # publish rtmp stream
   echo $i
   ffmpeg -nostdin -loglevel quiet -re -i trunk/doc/source.flv -c copy -f flv rtmp://localhost/live/livestream${i}?secret=fec73e1a68b84dc486240d9a9f952879 2>/dev/null &
done
```
the `trunk/doc/source.flv` is the test video source located at [srs](https://github.com/ossrs/srs)
the `secret token` is come from the `oryx`, check the oryx web UI.

2. script to pull 1000 hls streams from nginx cache.
```bash
#!/bin/bash
for ((i=1;i<=1000;i++)); 
do 
    # generate random number in range [1-50], represent which stream.
    r=`shuf -i 1-50 -n 1`
    echo $r
    ffmpeg -nostdin -loglevel quiet -i http://127.0.0.1/live/livestream${r}.m3u8 -f null - &
done
```

There is a k8s job to run this script in the cloud for the testing purpose.
https://gist.github.com/suzp1984/cc7d21e00b142c6f83a28d709b9954d3
```
apiVersion: batch/v1
kind: Job
metadata:
  name: ffmpeg-pull-test
spec:
  ttlSecondsAfterFinished: 120
  template:
    spec:
      containers:
      - name: ffmpeg
        image: "ossrs/oryx:v5.15.20"
        imagePullPolicy: IfNotPresent
        command:
        - bash
        - -c
        - |-
          echo "pull live streams by ffmpeg"
          echo "start 500 ffmpeg processes to pull streams"
          for ((i=1;i<=500;i++)); 
          do 
            # generate random number in range [1-50], represent which stream.
            r=`shuf -i 1-50 -n 1`
            echo $r
            ffmpeg -nostdin -loglevel quiet -i http://127.0.0.1/live/livestream${r}.m3u8 -f null - &
          done
          
          while true; do
            sleep 1
            if [[ $(ps aux |grep ffmpeg |grep -v grep |grep -v usr |grep -q ffmpeg || echo no) == no ]]; then
              echo "all ffmpeg process done"
              break
            fi
          done
          echo "complete ffmpeg job"
      restartPolicy: Never
  backoffLimit: 4
```

3. monitor pods metric
`kubectl top pod` and `kubectl top node`
