### PR TITLE
fix srs-server helm chart port config problem.

### DIFF
--- a/srs-server/templates/deployment.yaml
+++ b/srs-server/templates/deployment.yaml
@@ -36,19 +36,19 @@ spec:
           command: ["./objs/srs", "-e"]
           ports:
             - name: rtmp
-              containerPort: {{ .Values.service.rtmp }}
+              containerPort: 1935
               protocol: TCP
             - name: http
-              containerPort: {{ .Values.service.http }}
+              containerPort: 8080
               protocol: TCP
             - name: api
-              containerPort: {{ .Values.service.api }}
+              containerPort: 1985
               protocol: TCP
             - name: srt
-              containerPort: {{ .Values.service.srt }}
+              containerPort: 10080
               protocol: UDP
             - name: rtc
-              containerPort: {{ .Values.service.rtc }}
+              containerPort: 8000
               protocol: UDP
           env:
             # The general default config.
@@ -86,12 +86,20 @@ spec:
               value: "off"
           livenessProbe:
             httpGet:
-              path: /
-              port: http
+              path: /api/v1/versions
+              port: api
+            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /
               port: http
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /api/v1/versions
+              port: api
+            failureThreshold: 3
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/srs-server/values.yaml
+++ b/srs-server/values.yaml
@@ -14,6 +14,7 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+# simple set replicaCount more than one don't make sense, because the default srs config is stateful app.
 replicaCount: 1
 
 # The configuration for SRS can be overridden by environment variables.
@@ -107,6 +108,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# simple open autoscaling don't make sense, because the default srs config is stateful app.
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
1. fix the srs container ports config, must be hardcode to predefined ports;
2. add comments to remind don't simplify config replicaCount or open autoscaling, those config is for stateless app deployment, e.g. srs edges;
3. add startupProbe and change livenessProbe to /api/v1/versions endpoint, this change don't fix anything, just add more container proble and its default configs: failtureThreshold, periodSeconds;


## How to reproduce Port Config problem?
In `main` branch.
1. `helm install srs srs-server/ --debug --set service.http=8088`
2. access `http://localhost:8088` in web browser. No response.

